### PR TITLE
Feat [Cli] Logger

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -7,6 +7,7 @@ package main
 
 import (
 	"context"
+	"log"
 	"os"
 	"os/signal"
 	"syscall"
@@ -18,6 +19,9 @@ import (
 var version = "0.1.1" // default version if not set
 
 func main() {
+	// Disable the default timestamp in log output
+	log.SetFlags(0)
+
 	// Create a context that can be cancelled
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -25,6 +29,10 @@ func main() {
 	// Set up signal handling
 	sigs := make(chan os.Signal, 1)
 	signal.Notify(sigs, syscall.SIGINT, syscall.SIGTERM)
+
+	// Log start with version
+	log.Printf("Starting TLS certificate chain resolver (v%s)...", version)
+	log.Println("Press CTRL+C to exit.")
 
 	// Run the CLI in a separate goroutine
 	go func() {
@@ -34,9 +42,15 @@ func main() {
 	// Wait for a termination signal
 	<-sigs
 
+	// Log exit instruction
+	log.Println("\nReceived termination signal. Exiting...")
+
 	// Cancel the context to stop the CLI
 	cancel()
 
 	// Give some time for cleanup
 	time.Sleep(3 * time.Second)
+
+	// Log stop
+	log.Println("TLS certificate chain resolver stopped.")
 }


### PR DESCRIPTION
- [+] feat(run.go): disable default timestamp in log output and log start and stop messages
- [+] fix(root.go): replace error handling with log.Fatalf for better logging and add logging for each certificate in the chain