### PR TITLE
Improve [Makefile] Binary Builder for MacOS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,12 +24,22 @@ build-linux:
 	@GOOS=linux GOARCH=amd64 go build -ldflags="-X main.version=$(VERSION)" -o $(BUILD_DIR)/linux/$(BINARY_NAME) ./cmd
 	@echo "Build complete: $(BUILD_DIR)/linux/$(BINARY_NAME)"
 
-# Build the binary for macOS
-build-macos:
-	@echo "Building $(BINARY_NAME) for macOS version $(VERSION)..."
-	@mkdir -p $(BUILD_DIR)/macos
-	@GOOS=darwin GOARCH=amd64 go build -ldflags="-X main.version=$(VERSION)" -o $(BUILD_DIR)/macos/$(BINARY_NAME) ./cmd
-	@echo "Build complete: $(BUILD_DIR)/macos/$(BINARY_NAME)"
+# Build the binary for macOS (amd64)
+build-macos-amd64:
+	@echo "Building $(BINARY_NAME) for macOS (amd64) version $(VERSION)..."
+	@mkdir -p $(BUILD_DIR)/macos/amd64
+	@GOOS=darwin GOARCH=amd64 go build -ldflags="-X main.version=$(VERSION)" -o $(BUILD_DIR)/macos/amd64/$(BINARY_NAME) ./cmd
+	@echo "Build complete: $(BUILD_DIR)/macos/amd64/$(BINARY_NAME)"
+
+# Build the binary for macOS (arm64)
+build-macos-arm64:
+	@echo "Building $(BINARY_NAME) for macOS (arm64) version $(VERSION)..."
+	@mkdir -p $(BUILD_DIR)/macos/arm64
+	@GOOS=darwin GOARCH=arm64 go build -ldflags="-X main.version=$(VERSION)" -o $(BUILD_DIR)/macos/arm64/$(BINARY_NAME) ./cmd
+	@echo "Build complete: $(BUILD_DIR)/macos/arm64/$(BINARY_NAME)"
+
+# Build the binary for macOS (both architectures)
+build-macos: build-macos-amd64 build-macos-arm64
 
 # Build the binary for Windows
 build-windows:
@@ -51,4 +61,4 @@ clean:
 	@echo "Clean complete."
 
 # PHONY targets
-.PHONY: all build-linux build-macos build-windows test clean
+.PHONY: all build-linux build-macos build-macos-amd64 build-macos-arm64 build-windows test clean


### PR DESCRIPTION
- [+] feat(Makefile): add separate build targets for macOS amd64 and arm64 architectures and update build-macos target to build for both architectures