### PR TITLE
Remove Time Sleep when Operation Performed Successfully

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -11,7 +11,6 @@ import (
 	"os"
 	"os/signal"
 	"syscall"
-	"time"
 
 	"github.com/H0llyW00dzZ/tls-cert-chain-resolver/src/cli"
 )
@@ -56,8 +55,6 @@ func main() {
 
 	// Log stop only if an operation was performed successfully
 	if cli.OperationPerformedSuccessfully {
-		// Give some time for cleanup
-		time.Sleep(1 * time.Second)
 		log.Println("TLS certificate chain resolver stopped.")
 	}
 }


### PR DESCRIPTION
- [+] refactor(run.go): remove unused time package and cleanup delay before logging stop message