### PR TITLE
Improve [Makefile] Binary Builder For Linux

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ return:
 build-linux: checkout
 	@echo "Building $(BINARY_NAME) for Linux version $(VERSION)..."
 	@mkdir -p $(BUILD_DIR)/linux
-	@GOOS=linux GOARCH=amd64 go build -ldflags="-X main.version=$(VERSION)" -o $(BUILD_DIR)/linux/$(BINARY_NAME) ./cmd
+	@CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags="-X main.version=$(VERSION) -s -w" -o $(BUILD_DIR)/linux/$(BINARY_NAME) ./cmd
 	@echo "Build complete: $(BUILD_DIR)/linux/$(BINARY_NAME)"
 	@$(MAKE) return
 

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -15,7 +15,7 @@ import (
 	"github.com/H0llyW00dzZ/tls-cert-chain-resolver/src/cli"
 )
 
-var version = "0.2.6" // default version if not set
+var version = "0.2.7" // default version if not set
 
 func main() {
 	// Disable the default timestamp in log output


### PR DESCRIPTION
- [+] chore(Makefile): set CGO_ENABLED=0 for Linux build and optimize build flags
- [+] chore(run.go): update default version to 0.2.7