### PR TITLE
Update Knowledge Base for Unix AI Agent to Reflect Recent Code Changes

### DIFF
--- a/.github/instructions/deepwiki.instructions.md
+++ b/.github/instructions/deepwiki.instructions.md
@@ -474,7 +474,7 @@ Solutions:
 - `modelcontextprotocol/go-sdk` v1.2.0 - For official MCP transport implementations
 - `google.golang.org/adk` v0.3.0 - For Google ADK integration for MCP transport creation
 - `google.golang.org/genai` v1.42.0 - For Google GenAI integration for AI model interactions
-- `github.com/olekukonko/tablewriter` v1.1.2 - For enhanced markdown table formatting with emoji headers
+- `github.com/olekukonko/tablewriter` v1.1.3 - For enhanced markdown table formatting with emoji headers
 - `gopkg.in/yaml.v3` v3.0.1 - For YAML configuration file support (GitHub: go-yaml/yaml)
 - `golang.org/x/crypto` v0.47.0 - For supplementary cryptography libraries leveraged in recent releases
 - `golang.org/x/text` v0.33.0 - For text processing utilities for proper casing and internationalization (GitHub: golang/text)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,7 +78,7 @@
 - `github.com/modelcontextprotocol/go-sdk` v1.2.0 - Official MCP SDK for transport implementations
 - `google.golang.org/adk` v0.3.0 - Google ADK integration for MCP transport creation
 - `google.golang.org/genai` v1.42.0 - Google GenAI integration for AI model interactions
-- `github.com/olekukonko/tablewriter` v1.1.2 - Enhanced markdown table formatting with emoji headers
+- `github.com/olekukonko/tablewriter` v1.1.3 - Enhanced markdown table formatting with emoji headers
 - `github.com/xeipuuv/gojsonschema` v1.2.0 - JSON schema validation for code generation
 - `gopkg.in/yaml.v3` v3.0.1 - YAML configuration file support for MCP server
 - `golang.org/x/text` v0.33.0 - Text processing utilities for proper casing and internationalization


### PR DESCRIPTION
* docs(deps): update tablewriter dependency version to v1.1.3

- [+] Update version in .github/instructions/deepwiki.instructions.md
- [+] Update version in AGENTS.md