### PR TITLE
Update Knowledge Base for Unix AI Agent to Reflect Recent Code Changes

### DIFF
--- a/.github/instructions/deepwiki.instructions.md
+++ b/.github/instructions/deepwiki.instructions.md
@@ -473,7 +473,7 @@ Solutions:
 - `mark3labs/mcp-go` v0.43.2 - For MCP server features with enhanced bidirectional AI sampling support
 - `modelcontextprotocol/go-sdk` v1.2.0 - For official MCP transport implementations
 - `google.golang.org/adk` v0.3.0 - For Google ADK integration for MCP transport creation
-- `google.golang.org/genai` v1.42.0 - For Google GenAI integration for AI model interactions
+- `google.golang.org/genai` v1.43.0 - For Google GenAI integration for AI model interactions
 - `github.com/olekukonko/tablewriter` v1.1.3 - For enhanced markdown table formatting with emoji headers
 - `gopkg.in/yaml.v3` v3.0.1 - For YAML configuration file support (GitHub: go-yaml/yaml)
 - `golang.org/x/crypto` v0.47.0 - For supplementary cryptography libraries leveraged in recent releases

--- a/.github/instructions/x509_resolver.md
+++ b/.github/instructions/x509_resolver.md
@@ -208,7 +208,7 @@ x509_resolver_get_resource_usage(detailed=true, format="markdown")
 - Integrates with CRL cache metrics from `src/internal/x509/chain/cache.go`
 - Provides hit rate calculations and memory usage in MB for readability
 - Thread-safe data collection using atomic operations for cache metrics
-- Enhanced markdown formatting using `github.com/olekukonko/tablewriter` v1.1.1 with emoji headers and structured tables
+- Enhanced markdown formatting using `github.com/olekukonko/tablewriter` v1.1.3 with emoji headers and structured tables
 - Human-readable timestamp formatting for better user experience
 
 ### x509_resolver_visualize_cert_chain(certificate, format?)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -77,7 +77,7 @@
 - `github.com/mark3labs/mcp-go` v0.43.2 - MCP server implementation with enhanced bidirectional AI sampling support
 - `github.com/modelcontextprotocol/go-sdk` v1.2.0 - Official MCP SDK for transport implementations
 - `google.golang.org/adk` v0.3.0 - Google ADK integration for MCP transport creation
-- `google.golang.org/genai` v1.42.0 - Google GenAI integration for AI model interactions
+- `google.golang.org/genai` v1.43.0 - Google GenAI integration for AI model interactions
 - `github.com/olekukonko/tablewriter` v1.1.3 - Enhanced markdown table formatting with emoji headers
 - `github.com/xeipuuv/gojsonschema` v1.2.0 - JSON schema validation for code generation
 - `gopkg.in/yaml.v3` v3.0.1 - YAML configuration file support for MCP server


### PR DESCRIPTION
* docs: update dependency versions in documentation

- [+] Bump `google.golang.org/genai` to v1.43.0 in deepwiki.instructions.md and AGENTS.md
- [+] Bump `github.com/olekukonko/tablewriter` to v1.1.3 in x509_resolver.md